### PR TITLE
Do not initialize wiringPi in the module

### DIFF
--- a/dccpi/dcc_rpi_encoder.py
+++ b/dccpi/dcc_rpi_encoder.py
@@ -59,7 +59,7 @@ class DCCRPiEncoder(DCCEncoder):
                             bit_zero_part_max_duration,
                             bit_zero_part_duration,
                             packet_separation)
-
+        dcc_rpi_encoder_c.setup()
         self._string_payload = ""
         self._idle_packet_string = self.idle_packet.to_bit_string()
         self._reset_packet_string = self.reset_packet.to_bit_string()


### PR DESCRIPTION
"""wiringPi doesn't need to be enabled by default, as a custom RPiEncoder
could be written or even wiringPi might have been set up before."""

Hi,
I'd like to use dccpi but also get decoder programming to work (at least loco address and speed steps). I plan to write a custom rpi encoder which also includes feedback from the SGND channel.

If I should split my patch into two (constants for pins and external setup routine) or you have other suggestions, please let me know!

Thanks a lot for your work, I was quite pleased today when I got my loco running with your software (& hardware setup) without having a commercial command station!

regards, Patrick